### PR TITLE
Fixed bug with ADC fallback when unplugged and improved crosscompile script.

### DIFF
--- a/autoapp/Service/SteeringWheelControl.cpp
+++ b/autoapp/Service/SteeringWheelControl.cpp
@@ -61,9 +61,11 @@ Qt::Key fromHandsFreeMeasurement(float adcVoltage)
 
 void SteeringWheelControl::run()
 {
+    int8_t testBuf = { 0 };
     if (
         (i2cFileDescriptor_ = open("/dev/i2c-1", O_RDWR)) < 0 ||
-        ioctl(i2cFileDescriptor_, I2C_SLAVE, 0x48) < 0
+        ioctl(i2cFileDescriptor_, I2C_SLAVE, 0x48) < 0 ||
+        read(i2cFileDescriptor_, &testBuf, 1) < 1
     ) {
         OPENAUTO_LOG(error) << "[SteeringWheelControl] Failed to initialize ADC";
         close(i2cFileDescriptor_);

--- a/tooling/crosscompile.ps1
+++ b/tooling/crosscompile.ps1
@@ -1,5 +1,9 @@
 
-$sshTarget=$args[0]
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)]
+  [String]$sshTarget
+)
 
 $buildFolder = "buildcross"
 $resultingBinaryPath = "$buildFolder/assets/autoapp"


### PR DESCRIPTION
This fixes a bug on the ADC detection. When we have a bus but no device plugged in it will proceed with the controls.

Improved the cross compile script to request the parameter if not set.

