### PR TITLE
Fix an issue with button presses when touch screen is disabled.

### DIFF
--- a/openauto/Projection/InputDevice.cpp
+++ b/openauto/Projection/InputDevice.cpp
@@ -176,6 +176,7 @@ bool InputDevice::handleKeyEvent(QEvent* event, QKeyEvent* key)
     }
     return true;
 }
+
 bool InputDevice::handleTouchEvent(QEvent* event)
 {
     if(!configuration_->getTouchscreenEnabled())


### PR DESCRIPTION
When the touch screen is disabled button presses do not work.

It appears that not all buttons needs to be initialized. Doing just 1 appears to work but some call to set whether it be button presses or touchscreen needs to be made to initialize input.  

I have just set all used buttons for now incase this behaviour changes in the future.