### PR TITLE
Loosened SWC bottom range due to varying measured resistance.

### DIFF
--- a/autoapp/Service/SteeringWheelControl.cpp
+++ b/autoapp/Service/SteeringWheelControl.cpp
@@ -16,8 +16,8 @@ namespace {
 
 Qt::Key fromVoltageReading(float adcVoltage) {
     const std::map<Qt::Key, std::pair<float, float>> KEY_MAP = {
-        {Qt::Key_VolumeUp, { 0.710, 0.740 }},
-        {Qt::Key_VolumeDown, { 1.220, 1.250 }},
+        {Qt::Key_VolumeUp, { 0.710, 0.770 }},
+        {Qt::Key_VolumeDown, { 1.230, 1.270 }},
         {Qt::Key_H, { 1.600, 1.630 }},  // hook on => home
         {Qt::Key_B, { 1.670, 1.700 }},  // mode => play/pause
         {Qt::Key_N, { 2.130, 2.160 }},  // seek+ => media next


### PR DESCRIPTION
Resistance values of 0.754V and 1.256V were measured when the volume controls were not working. Loosening the lower range to catch this condition.

Upper range buttons were tight but met conditions. For example Mode was 1.693V which is on the upper end but still below thresholds.

Without digging into it to much further I assume the cause is varying resistance in the components due to head and movement.

