### PR TITLE
Increase audio buffer to avoid stuttering on wireless.

### DIFF
--- a/openauto/Projection/QtAudioOutput.cpp
+++ b/openauto/Projection/QtAudioOutput.cpp
@@ -37,7 +37,7 @@ QtAudioOutput::QtAudioOutput(uint32_t channelCount, uint32_t sampleSize, uint32_
     audioFormat_.setByteOrder(QAudioFormat::LittleEndian);
     audioFormat_.setSampleType(QAudioFormat::SignedInt);
 
-   QThread * th = QApplication::instance()->thread();
+    QThread * th = QApplication::instance()->thread();
     this->moveToThread(th);
     th->setPriority(QThread::TimeCriticalPriority);
 
@@ -52,6 +52,7 @@ void QtAudioOutput::createAudioOutput()
 {
     OPENAUTO_LOG(debug) << "[QtAudioOutput] create.";
     audioOutput_ = std::make_unique<QAudioOutput>(QAudioDeviceInfo::defaultOutputDevice(), audioFormat_);
+    audioOutput_->setBufferSize(audioFormat_.bytesForDuration(1000 * 1000));
 }
 
 bool QtAudioOutput::open()


### PR DESCRIPTION
I'm unsure what the previous buffer was but increasing this value has removed stuttering in most scenarios.

I've set it a bit higher than it needs to be. 500ms is satisfactory in good conditions but I went with 1s to allow for a bad connection. There is no appreciable delay in the output so I'd rather avoid the occasional stutter.

This will need to be applied in combination with fixing realtime/niceness permissions on Pipewire. 