### PR TITLE
Stop emitting night data sensor. Change volume indication timeout.

### DIFF
--- a/autoapp/Pages/ProjectionPage.cpp
+++ b/autoapp/Pages/ProjectionPage.cpp
@@ -61,7 +61,7 @@ void ProjectionPage::showVolumeIndicator()
     ui_->volumeIndicator->show();
     ui_->volumeIndicator->move(aaFrame->width() / 7, aaFrame->height() - (aaFrame->height() / 16) - 15);
     ui_->volumeIndicator->setFocus();
-    volumeIndicationTimeout_->start(2000);
+    volumeIndicationTimeout_->start(1000);
 }
 
 

--- a/openauto/Service/SensorService.cpp
+++ b/openauto/Service/SensorService.cpp
@@ -57,7 +57,7 @@ void SensorService::fillFeatures(aasdk::proto::messages::ServiceDiscoveryRespons
     auto* sensorChannel = channelDescriptor->mutable_sensor_channel();
     sensorChannel->add_sensors()->set_type(aasdk::proto::enums::SensorType::DRIVING_STATUS);
     //sensorChannel->add_sensors()->set_type(aasdk::proto::enums::SensorType::LOCATION);
-    sensorChannel->add_sensors()->set_type(aasdk::proto::enums::SensorType::NIGHT_DATA);
+    // sensorChannel->add_sensors()->set_type(aasdk::proto::enums::SensorType::NIGHT_DATA);
 }
 
 void SensorService::onChannelOpenRequest(const aasdk::proto::messages::ChannelOpenRequest& request)


### PR DESCRIPTION
Some minor tweak: 

- Stop emitting night sensor data in order to try get phone recognition on AA auto. This does not appear to be functional at this point but we aren't using the service anyway.
- Change volume indication timeout based on usage. This allows quicker controls between SWC and the keypad knob.