### PR TITLE
Docker speedup using named volume.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 		"PULSE_SERVER": "tcp:host.docker.internal"
 	},
 	"mounts": [
-		"source=${localWorkspaceFolder}/.devcontainer/.bash_profile,target=/root/.bash_profile,type=bind,consistency=cached"
+		"source=openauto-builds,target=${containerWorkspaceFolder}/builds,type=volume"
 	],
 	"runArgs": [
 		"--net=host"


### PR DESCRIPTION
Cross compile builds (from scratch) were taking a long time due to having to do aasdk protos as well. In particular when the devcontainer was open with cross compiles happening the disk usage spiked.

This moves all builds (by default) into a named volume.

Additionally:
- The `.bash_profile` file mount has been removed as it was never really used and causes errors if the file goes missing.
- The cross compile script now does release builds. Options to do different presets can be added later.